### PR TITLE
added padding to G component

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -139,7 +139,7 @@ export default class CircularProgress extends React.PureComponent {
     return (
       <View style={style}>
         <Svg width={size + padding} height={size + padding}>
-          <G rotation={rotation} originX={size / 2} originY={size / 2}>
+          <G rotation={rotation} originX={(size + padding) / 2} originY={size + padding / 2}>
             {backgroundColor && (
               <Path
                 d={backgroundPath}


### PR DESCRIPTION
adding padding prevents the circle clipping that happens when the rendercap circle is at the top of the circle